### PR TITLE
Profile indicando qual configuração usar no servidor

### DIFF
--- a/LINKS.md
+++ b/LINKS.md
@@ -38,3 +38,11 @@
 
 * <https://sourceforge.net/projects/pisnes/>
 * <https://gitlab.com/higan/higan>
+
+## Emuladores Nintendo 64
+
+* <http://www.mupen64plus.org/wiki/index.php?title=KeyboardSetup>
+* <https://github.com/mupen64plus/mupen64plus-ui-python>
+* <https://github.com/mupen64plus/mupen64plus-core/releases>
+* <https://sourceforge.net/projects/cutemupen/>
+

--- a/src/pages/Config.vue
+++ b/src/pages/Config.vue
@@ -22,14 +22,29 @@
                             v-model="mqtt.port">
                     </p>
 
-                    <label class="label" for="pad_type">PAD Type</label>
-                    <p class="control">
-                        <span class="select">
-                            <select id="pad_type" v-model="pad.type">
-                                <option value="race">Race</option>
-                            </select>
-                        </span>
-                    </p>
+                    <div class="columns is-mobile">
+                        <div class="column">
+                            <label class="label" for="pad_type">PAD Type</label>
+                            <p class="control">
+                                <span class="select">
+                                    <select id="pad_type" v-model="pad.type">
+                                        <option value="race">Race</option>
+                                    </select>
+                                </span>
+                            </p>
+                        </div>
+                        <div class="column">
+                            <label class="label" for="pad_profile">PAD Profile</label>
+                            <p class="control">
+                                <span class="select">
+                                    <select id="pad_profile" v-model="pad.profile">
+                                        <option value="snes--top_gear">SNES - Top Gear</option>
+                                        <option value="n64--mario_kart">N64 - Mario Kart</option>
+                                    </select>
+                                </span>
+                            </p>
+                        </div>
+                    </div>
 
                     <label class="label" for="player">Player</label>
                     <p class="control">
@@ -108,13 +123,14 @@ export default {
         return {
             mqtt: {
                 hostname: '',
-                port: 1884
+                port: 0
             },
             pad: {
-                type: 'race',
-                enabled: false
+                type: '',
+                enabled: false,
+                profile: ''
             },
-            player: 'alice',
+            player: '',
             accelerationSensibility: 2
         }
     },

--- a/src/store.js
+++ b/src/store.js
@@ -8,7 +8,8 @@ const store = new Vuex.Store({
         player: 'alice',
         pad: {
             enabled: false,
-            type: 'race'
+            type: 'race',
+            profile: 'snes--top_gear'
         },
         mqtt: {
             hostname: window.location.hostname,


### PR DESCRIPTION
Com um profile é posível usar o mesmo Pad com configurações de
teclas diferentes, por exemplo um jogo de corrida no SNES usa
teclas diferentes em um jogo de corrida do Nintendo 64, entretanto
o Pad é o mesmo.

As configurações de profile são enviadas em um tópico específico,
`settings/player`.

Os dados somente são enviados se o conjunto de teclas mudar. Isso
melhorou o uso da rede.